### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/spring-petclinic-admin-server-main.yaml
+++ b/.github/workflows/spring-petclinic-admin-server-main.yaml
@@ -115,7 +115,7 @@ jobs:
       
 #    - uses: actions/checkout@master
 #    - name: Publish to Registry
-#      uses: elgohr/Publish-Docker-Github-Action@master
+#      uses: elgohr/Publish-Docker-Github-Action@v5
 #      with:
 #       name: docker.io/omearaj/admin-server:latest
 #       username: ${{ env.REGISTRY_USERID }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore